### PR TITLE
Rename converter script to .py and add shebang

### DIFF
--- a/Easy_Video_Format_Converter.py
+++ b/Easy_Video_Format_Converter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 from pathlib import Path
 from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QFileDialog, QMessageBox, QComboBox, QLabel


### PR DESCRIPTION
## Summary
- rename the video converter script to `Easy_Video_Format_Converter.py`
- add Python shebang

## Testing
- `python Easy_Video_Format_Converter.py` *(fails: ModuleNotFoundError for PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_68574252b97c832c867a2c32397fc8ec