### PR TITLE
Make GUI icons optional

### DIFF
--- a/Folder Un-Organizer.py
+++ b/Folder Un-Organizer.py
@@ -46,7 +46,12 @@ class FolderUnOrganizer(QtWidgets.QMainWindow):
 
         self.setGeometry(600, 200, 600, 200)
         self.setWindowTitle("Folder Un-Organizer")
-        self.setWindowIcon(QtGui.QIcon("C:\\Users\\antho\\Downloads\\ico_files\\Funnel Pursuit.ico"))
+        # Attempt to set a window icon from a file in the same directory as this
+        # script. The icon is optional so the application continues even if the
+        # file is not present.
+        icon_path = os.path.join(os.path.dirname(__file__), "Funnel Pursuit.ico")
+        if os.path.exists(icon_path):
+            self.setWindowIcon(QtGui.QIcon(icon_path))
         self.show()
 
     def browse(self):

--- a/Sales and Marketing version 1.py
+++ b/Sales and Marketing version 1.py
@@ -44,8 +44,12 @@ class AffiliateReportApp(QtWidgets.QMainWindow):
         self.create_menu()
         self.setWindowTitle("Sales Report")
         
-        self.logo_pixmap = QtGui.QPixmap("C:/Users/antho/Documents/Python/logo.png/Funnel Pursuit.png")
-        self.setWindowIcon(QtGui.QIcon(self.logo_pixmap))
+        # Try to load an application icon from a file located next to this
+        # script.  If the icon does not exist the application will still run
+        # without setting a window icon.
+        icon_path = os.path.join(os.path.dirname(__file__), "Funnel Pursuit.png")
+        if os.path.exists(icon_path):
+            self.setWindowIcon(QtGui.QIcon(icon_path))
         self.resize(1300, 400)
         self.central_widget = QtWidgets.QWidget(self)
         

--- a/Youtube Audio Download Program.py
+++ b/Youtube Audio Download Program.py
@@ -17,8 +17,10 @@ class Application(QtWidgets.QMainWindow):
         self.setWindowTitle("YouTube Video Downloader")
         self.resize(400, 200)
 
-        self.logo_pixmap = QtGui.QPixmap("C:/Users/antho/Documents/Python/logo.png/Funnel Pursuit.png")
-        self.setWindowIcon(QtGui.QIcon(self.logo_pixmap))
+        # Optional application icon loaded from the same directory as this file
+        icon_path = os.path.join(os.path.dirname(__file__), "Funnel Pursuit.png")
+        if os.path.exists(icon_path):
+            self.setWindowIcon(QtGui.QIcon(icon_path))
 
         self.central_widget = QtWidgets.QWidget(self)
 
@@ -117,8 +119,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("YouTube Video Downloader")
         self.resize(400, 200)
 
-        self.logo_pixmap = QtGui.QPixmap("C:/Users/antho/Documents/Python/logo.png/Funnel Pursuit.png")
-        self.setWindowIcon(QtGui.QIcon(self.logo_pixmap))
+        icon_path = os.path.join(os.path.dirname(__file__), "Funnel Pursuit.png")
+        if os.path.exists(icon_path):
+            self.setWindowIcon(QtGui.QIcon(icon_path))
 
         self.central_widget = QtWidgets.QWidget(self)
 


### PR DESCRIPTION
## Summary
- load icons relative to the script instead of hard-coded paths
- allow programs to run even if icon files are missing

## Testing
- `python -m py_compile 'Sales and Marketing version 1.py' 'Youtube Audio Download Program.py' 'Folder Un-Organizer.py'`

------
https://chatgpt.com/codex/tasks/task_e_685742539438832cb6d27f2ac22b8e56